### PR TITLE
Fix undo behavior when AI hasn't moved

### DIFF
--- a/lib/screens/game_mainscreen.dart
+++ b/lib/screens/game_mainscreen.dart
@@ -332,13 +332,17 @@ class _GameScreenState extends State<GameScreen> {
   }
 
   void _undoLastMove() {
-    if (moveHistory.length < 2) return;
+    if (moveHistory.isEmpty) return;
     setState(() {
       final lastMove = moveHistory.removeLast();
       displayXO[lastMove['index']] = '';
 
-      final secondLastMove = moveHistory.removeLast();
-      displayXO[secondLastMove['index']] = '';
+      // If the undone move belonged to the AI, also revert the preceding
+      // player move so the board state stays consistent.
+      if (lastMove['symbol'] == 'O' && moveHistory.isNotEmpty) {
+        final previousMove = moveHistory.removeLast();
+        displayXO[previousMove['index']] = '';
+      }
 
       matchedIndexes.clear();
       resultDeclaration = '';


### PR DESCRIPTION
## Summary
- correct undo logic so player can undo their move before the AI responds

## Testing
- `dart test` *(fails: `dart` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac443c8a8832faa2e68fb5984e6d3