### PR TITLE
Fix opposite corner check

### DIFF
--- a/lib/hardLogic.dart
+++ b/lib/hardLogic.dart
@@ -139,7 +139,7 @@ int? _checkOppositeCorner(List<String> board, String userSym) {
   for (var corner in corners) {
     if (board[corner] == userSym) {
       int opposite = _getOppositeCorner(corner);
-      if (board[opposite].isEmpty) {
+      if (opposite != -1 && board[opposite].isEmpty) {
         return opposite;
       }
     }


### PR DESCRIPTION
## Summary
- avoid invalid index in `_checkOppositeCorner`

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_685ad3c4c960832fb74e605f2be9c5af